### PR TITLE
GitHub Actions enable build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1
+    - name: Clean-up GitHub Actions Diskspace
+      run: powershell .\AzurePipelines\github-actions-free-disk.ps1
     - name: Install LabVIEW NXG
       run: powershell .\AzurePipelines\install.ps1
     - name: Start capturing screenshots

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,29 +11,29 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1
-    # - name: Install LabVIEW NXG
-    #   run: powershell .\AzurePipelines\install.ps1
-    # - name: Start capturing screenshots
-    #   working-directory: ./AzurePipelines/periodic-screenshot
-    #   run: |
-    #     npm install
-    #     npm run start
-    # - name: Build LabVIEW Projects
-    #   run: powershell .\AzurePipelines\build.ps1
-    #   timeout-minutes: 60
-    #   continue-on-error: true
-    # - name: Stop capturing screenshots
-    #   working-directory: ./AzurePipelines/periodic-screenshot
-    #   run: npm run stop
-    # - name: Upload screenshots
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: screenshots
-    #     path: ./AzurePipelines/periodic-screenshot/dist
-    # - name: Create GitHub Pages Output
-    #   run: powershell .\AzurePipelines\ghpages.ps1
-    # - name: Upload GitHub Pages Output
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: ghpagesarchive
-    #     path: ./ghpagesarchive
+    - name: Install LabVIEW NXG
+      run: powershell .\AzurePipelines\install.ps1
+    - name: Start capturing screenshots
+      working-directory: ./AzurePipelines/periodic-screenshot
+      run: |
+        npm install
+        npm run start
+    - name: Build LabVIEW Projects
+      run: powershell .\AzurePipelines\build.ps1
+      timeout-minutes: 60
+      continue-on-error: true
+    - name: Stop capturing screenshots
+      working-directory: ./AzurePipelines/periodic-screenshot
+      run: npm run stop
+    - name: Upload screenshots
+      uses: actions/upload-artifact@v1
+      with:
+        name: screenshots
+        path: ./AzurePipelines/periodic-screenshot/dist
+    - name: Create GitHub Pages Output
+      run: powershell .\AzurePipelines\ghpages.ps1
+    - name: Upload GitHub Pages Output
+      uses: actions/upload-artifact@v1
+      with:
+        name: ghpagesarchive
+        path: ./ghpagesarchive

--- a/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
+++ b/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
@@ -39,8 +39,6 @@ function Run {
     
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
     $pinfo.FileName = $fileName
-    $pinfo.RedirectStandardError = $true
-    $pinfo.RedirectStandardOutput = $true
     $pinfo.UseShellExecute = $false
     $pinfo.Arguments = $arguments
     if ($workingdirectory) {
@@ -48,35 +46,8 @@ function Run {
     }
     $p = New-Object System.Diagnostics.Process
     $p.StartInfo = $pinfo
-    
-    $out = New-Object System.Collections.ArrayList
-    $handler = 
-    {
-        if ($EventArgs.Data -is [String] -And ! [String]::IsNullOrEmpty($EventArgs.Data)) 
-        {
-            # $Event.MessageData.Add($EventArgs.Data)
-        }
-    }
-    
-    $outEvent = Register-ObjectEvent -InputObject $p -Action $handler -EventName 'OutputDataReceived' -MessageData $out
-        
-    $p.Start() | Out-Null
-    $p.BeginOutputReadLine()	
-    while (!$p.HasExited)
-    {
-        Wait-Event -Timeout 1
-        while($out.Length -gt 0)
-        {
-            $out[0].ToString()
-            $out.RemoveAt(0)
-        }
-    }
-    while($out.Length -gt 0)
-    {
-        $out[0].ToString()
-        $out.RemoveAt(0)
-    }
-    Unregister-Event -SourceIdentifier $outEvent.Name
+    $p.Start();
+    $p.WaitForExit();
 }
 
 function Watch-TrialWindow

--- a/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
+++ b/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
@@ -114,4 +114,8 @@ function Invoke-CopyBuildOutput {
     }
 }
 
-Export-ModuleMember -Function Assert-FileExists, Assert-FileDoesNotExist, Run, Invoke-NXGBuildApplication, Invoke-CopyBuildOutput
+function Invoke-PrintDiskspace {
+    Get-WmiObject -Class Win32_logicaldisk
+}
+
+Export-ModuleMember -Function Assert-FileExists, Assert-FileDoesNotExist, Run, Invoke-NXGBuildApplication, Invoke-CopyBuildOutput, Invoke-PrintDiskspace

--- a/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
+++ b/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
@@ -129,4 +129,14 @@ function Invoke-MinimizeWindows {
     $shell.minimizeall()
 }
 
-Export-ModuleMember -Function Assert-FileExists, Assert-FileDoesNotExist, Run, Invoke-NXGBuildApplication, Invoke-CopyBuildOutput, Invoke-PrintDiskspace, Invoke-DeletePackages, Invoke-MinimizeWindows
+function Invoke-PrintFolderSizes {
+    Param ([string]$path)
+    $colItems = Get-ChildItem $path | Where-Object {$_.PSIsContainer -eq $true} | Sort-Object
+    foreach ($i in $colItems)
+    {
+        $subFolderItems = Get-ChildItem $i.FullName -recurse -force | Where-Object {$_.PSIsContainer -eq $false} | Measure-Object -property Length -sum | Select-Object Sum
+        $i.FullName + " -- " + "{0:N2}" -f ($subFolderItems.sum / 1MB) + " MB"
+    }
+}
+
+Export-ModuleMember -Function Assert-FileExists, Assert-FileDoesNotExist, Run, Invoke-NXGBuildApplication, Invoke-CopyBuildOutput, Invoke-PrintDiskspace, Invoke-DeletePackages, Invoke-MinimizeWindows, Invoke-PrintFolderSizes

--- a/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
+++ b/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
@@ -79,6 +79,7 @@ function Invoke-NXGBuildApplication {
 
     $process = Watch-TrialWindow
     Write-Host "Running build command: $buildapplicationcommand"
+    Invoke-MinimizeWindows
     Run $labviewnxgcli $buildapplicationcommand
     try {
         Write-Host "AutoHotKey stopping"
@@ -123,4 +124,9 @@ function Invoke-DeletePackages {
     Write-Host $err
 }
 
-Export-ModuleMember -Function Assert-FileExists, Assert-FileDoesNotExist, Run, Invoke-NXGBuildApplication, Invoke-CopyBuildOutput, Invoke-PrintDiskspace, Invoke-DeletePackages
+function Invoke-MinimizeWindows {
+    $shell = New-Object -ComObject "Shell.Application"
+    $shell.minimizeall()
+}
+
+Export-ModuleMember -Function Assert-FileExists, Assert-FileDoesNotExist, Run, Invoke-NXGBuildApplication, Invoke-CopyBuildOutput, Invoke-PrintDiskspace, Invoke-DeletePackages, Invoke-MinimizeWindows

--- a/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
+++ b/AzurePipelines/NXGBuildTools/NXGBuildTools.psm1
@@ -118,4 +118,9 @@ function Invoke-PrintDiskspace {
     Get-WmiObject -Class Win32_logicaldisk
 }
 
-Export-ModuleMember -Function Assert-FileExists, Assert-FileDoesNotExist, Run, Invoke-NXGBuildApplication, Invoke-CopyBuildOutput, Invoke-PrintDiskspace
+function Invoke-DeletePackages {
+    Remove-Item "$Env:Programdata\National Instruments\NI Package Manager\Packages" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
+    Write-Host $err
+}
+
+Export-ModuleMember -Function Assert-FileExists, Assert-FileDoesNotExist, Run, Invoke-NXGBuildApplication, Invoke-CopyBuildOutput, Invoke-PrintDiskspace, Invoke-DeletePackages

--- a/AzurePipelines/github-actions-free-disk.ps1
+++ b/AzurePipelines/github-actions-free-disk.ps1
@@ -1,0 +1,14 @@
+Import-Module -Name "$PSScriptRoot\NXGBuildTools" -Verbose -Force
+
+Write-Host "Before removing some Program Files"
+Invoke-PrintFolderSizes("$Env:Programfiles")
+Invoke-PrintDiskspace
+
+Remove-Item "$Env:Programfiles\Unity" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
+Write-Host $err
+
+Remove-Item "$Env:Programfiles\Boost" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
+Write-Host $err
+
+Write-Host "After removing some Program Files"
+Invoke-PrintDiskspace

--- a/AzurePipelines/install.ps1
+++ b/AzurePipelines/install.ps1
@@ -1,5 +1,17 @@
 Import-Module -Name "$PSScriptRoot\NXGBuildTools" -Verbose -Force
 
+Write-Host "Before removing some Program Files"
+Invoke-PrintDiskspace
+
+Remove-Item "$Env:Programfiles\Unity" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
+Write-Host $err
+
+Remove-Item "$Env:Programdata\Boost" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
+Write-Host $err
+
+Write-Host "After removing some Program Files"
+Invoke-PrintDiskspace
+
 $rootDirectory = (Get-Location).Path
 Write-Host "Current directory $rootDirectory"
 

--- a/AzurePipelines/install.ps1
+++ b/AzurePipelines/install.ps1
@@ -25,6 +25,8 @@ if ($install_NIPM)
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
     Remove-Item $nipmInstaller
+
+    Add-Content "$Env:Localappdata\National Instruments\NI Package Manager\nipkg.ini" "[nipkg]`ncachepackages=false"
 }
 
 Assert-FileExists($nipm)

--- a/AzurePipelines/install.ps1
+++ b/AzurePipelines/install.ps1
@@ -52,7 +52,9 @@ if ($install_nxg)
     Run $nipm 'install ni-labview-nxg-4.0.0 --accept-eulas --assume-yes'
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
+    Invoke-PrintDiskspace
     Invoke-DeletePackages
+    Invoke-PrintDiskspace
 
     Write-Host "Installing LabVIEW NXG Web Module..."
     Invoke-PrintDiskspace
@@ -60,7 +62,9 @@ if ($install_nxg)
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
     Assert-FileExists($nxg)
+    Invoke-PrintDiskspace
     Invoke-DeletePackages
+    Invoke-PrintDiskspace
 }
 
 return

--- a/AzurePipelines/install.ps1
+++ b/AzurePipelines/install.ps1
@@ -27,6 +27,7 @@ if ($install_NIPM)
     Remove-Item $nipmInstaller
 
     Add-Content "$Env:Localappdata\National Instruments\NI Package Manager\nipkg.ini" "cachepackages=false"
+    Invoke-PrintFolderSizes("$Env:Programfiles")
 }
 
 Assert-FileExists($nipm)

--- a/AzurePipelines/install.ps1
+++ b/AzurePipelines/install.ps1
@@ -1,17 +1,5 @@
 Import-Module -Name "$PSScriptRoot\NXGBuildTools" -Verbose -Force
 
-Write-Host "Before removing some Program Files"
-Invoke-PrintDiskspace
-
-Remove-Item "$Env:Programfiles\Unity" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
-Write-Host $err
-
-Remove-Item "$Env:Programfiles\Boost" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
-Write-Host $err
-
-Write-Host "After removing some Program Files"
-Invoke-PrintDiskspace
-
 $rootDirectory = (Get-Location).Path
 Write-Host "Current directory $rootDirectory"
 
@@ -37,9 +25,6 @@ if ($install_NIPM)
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
     Remove-Item $nipmInstaller
-
-    Add-Content "$Env:Localappdata\National Instruments\NI Package Manager\nipkg.ini" "cachepackages=false"
-    Invoke-PrintFolderSizes("$Env:Programfiles")
 }
 
 Assert-FileExists($nipm)
@@ -61,6 +46,7 @@ if ($install_nxg)
     Run $nipm 'install ni-certificates --accept-eulas --assume-yes'
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
+    Invoke-PrintDiskspace
 
     Write-Host "Installing LabVIEW NXG..."
     Invoke-PrintDiskspace
@@ -68,18 +54,13 @@ if ($install_nxg)
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
     Invoke-PrintDiskspace
-    Invoke-DeletePackages
-    Invoke-PrintDiskspace
 
     Write-Host "Installing LabVIEW NXG Web Module..."
-    Invoke-PrintDiskspace
     Run $nipm 'install ni-labview-nxg-4.0.0-web-module --accept-eulas --assume-yes'
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
+    Invoke-PrintDiskspace
     Assert-FileExists($nxg)
-    Invoke-PrintDiskspace
-    Invoke-DeletePackages
-    Invoke-PrintDiskspace
 }
 
 return

--- a/AzurePipelines/install.ps1
+++ b/AzurePipelines/install.ps1
@@ -26,7 +26,7 @@ if ($install_NIPM)
     Write-Host "...done at UTC $time"
     Remove-Item $nipmInstaller
 
-    Add-Content "$Env:Localappdata\National Instruments\NI Package Manager\nipkg.ini" "[nipkg]`ncachepackages=false"
+    Add-Content "$Env:Localappdata\National Instruments\NI Package Manager\nipkg.ini" "cachepackages=false"
 }
 
 Assert-FileExists($nipm)

--- a/AzurePipelines/install.ps1
+++ b/AzurePipelines/install.ps1
@@ -6,7 +6,7 @@ Invoke-PrintDiskspace
 Remove-Item "$Env:Programfiles\Unity" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
 Write-Host $err
 
-Remove-Item "$Env:Programdata\Boost" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
+Remove-Item "$Env:Programfiles\Boost" -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable err
 Write-Host $err
 
 Write-Host "After removing some Program Files"

--- a/AzurePipelines/install.ps1
+++ b/AzurePipelines/install.ps1
@@ -17,7 +17,7 @@ if ($install_NIPM)
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
     Assert-FileExists($nipmInstaller)
-    
+
     Assert-FileDoesNotExist($nipm)
     Write-Host "Installing NIPM..."
     # Command line flags http://www.ni.com/documentation/en/ni-package-manager/latest/manual/automate-installer/
@@ -34,31 +34,33 @@ if ($install_nxg)
 {
     $nxg = "$Env:Programfiles\National Instruments\LabVIEW NXG 4.0\LabVIEW NXG.exe"
     Assert-FileDoesNotExist($nxg)
-    
+
     Write-Host "Adding LabVIEW NXG feeds to NI Package Manager"
     Run $nipm 'feed-add https://download.ni.com/support/nipkg/products/ni-l/ni-labview-nxg-4.0.0/7.1/released'
     Run $nipm 'feed-add https://download.ni.com/support/nipkg/products/ni-l/ni-labview-nxg-4.0.0-rte/7.1/released'
     Run $nipm 'feed-add https://download.ni.com/support/nipkg/products/ni-l/ni-labview-nxg-4.0.0-web-module/7.1/released'
     Run $nipm 'update'
-    
+
     Write-Host "Installing NI Certificates..."
     Invoke-PrintDiskspace
     Run $nipm 'install ni-certificates --accept-eulas --assume-yes'
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
-    
+
     Write-Host "Installing LabVIEW NXG..."
     Invoke-PrintDiskspace
     Run $nipm 'install ni-labview-nxg-4.0.0 --accept-eulas --assume-yes'
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
-    
+    Invoke-DeletePackages
+
     Write-Host "Installing LabVIEW NXG Web Module..."
     Invoke-PrintDiskspace
     Run $nipm 'install ni-labview-nxg-4.0.0-web-module --accept-eulas --assume-yes'
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
     Assert-FileExists($nxg)
+    Invoke-DeletePackages
 }
 
 return

--- a/AzurePipelines/install.ps1
+++ b/AzurePipelines/install.ps1
@@ -42,16 +42,19 @@ if ($install_nxg)
     Run $nipm 'update'
     
     Write-Host "Installing NI Certificates..."
+    Invoke-PrintDiskspace
     Run $nipm 'install ni-certificates --accept-eulas --assume-yes'
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
     
     Write-Host "Installing LabVIEW NXG..."
+    Invoke-PrintDiskspace
     Run $nipm 'install ni-labview-nxg-4.0.0 --accept-eulas --assume-yes'
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"
     
     Write-Host "Installing LabVIEW NXG Web Module..."
+    Invoke-PrintDiskspace
     Run $nipm 'install ni-labview-nxg-4.0.0-web-module --accept-eulas --assume-yes'
     $time = (Get-Date).ToUniversalTime()
     Write-Host "...done at UTC $time"


### PR DESCRIPTION
GitHub Actions started failing due to running out of disk space. This change adds logging for disk usage and deletes unneeded Program Files on the GirHub Actions hosted agents to free-up enough space for NXG install.